### PR TITLE
Fix `get_next_instruction()` returning `None`

### DIFF
--- a/desmume/emulator.py
+++ b/desmume/emulator.py
@@ -859,7 +859,7 @@ class DeSmuME_Memory:
 
     def get_next_instruction(self):
         """Returns the next instruction to be executed by the ARM9 processor."""
-        self.emu.lib.desmume_memory_get_next_instruction()
+        return self.emu.lib.desmume_memory_get_next_instruction()
 
     def set_next_instruction(self, address: int):
         """


### PR DESCRIPTION
The `get_next_instruction` function currently only calls the `desmume_memory_get_next_instruction()` without returning it. 