### PR TITLE
Add return type hint

### DIFF
--- a/desmume/emulator.py
+++ b/desmume/emulator.py
@@ -857,7 +857,7 @@ class DeSmuME_Memory:
         """Write a 4-byte integer to the memory at the specified address."""
         self.write(addr, addr, 4, [value])
 
-    def get_next_instruction(self):
+    def get_next_instruction(self) -> int:
         """Returns the next instruction to be executed by the ARM9 processor."""
         return self.emu.lib.desmume_memory_get_next_instruction()
 


### PR DESCRIPTION
I missed this in #27. Currently, IDE intellisense and type checkers like mypy don't know the return type of this function because it calls a desmume C++ binding function. The readthedocs documentation is also missing the return type, for the same reason.
To fix this, this PR explicitly specifies `int` as the return type.