### PR TITLE
Build wheels for Python 3.11

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           echo "PACKAGE_VERSION=$(python3 -- ./setup.py --version)" >> $GITHUB_ENV
       - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Upgrade pip
@@ -65,7 +65,7 @@ jobs:
         run: |
           echo "PACKAGE_VERSION=$(python3 -- ./setup.py --version)" >> $GITHUB_ENV
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.arch }}
@@ -157,7 +157,7 @@ jobs:
       - name: Download wheels
         uses: actions/download-artifact@v2
       - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Upgrade pip

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build Python wheels
         uses: RalfG/python-wheels-manylinux-build@v0.3.4-manylinux2014_x86_64
         with:
-          python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310'
+          python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
           pre-build-command: 'source ./build-manylinux.sh'
       - name: Upload wheels
         uses: actions/upload-artifact@v2
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ macos-10.15, windows-2019 ]
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
         arch: [ 'x64', 'x86' ]
         exclude:
           - os: macos-10.15


### PR DESCRIPTION
- Build wheels for Python 3.11
- Update setup-python action
  - `actions/setup-python@v1` fails to install Python 3.11 for Mac/Windows.