### PR TITLE
Add battery save import/export methods

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "desmume_src"]
 	path = desmume_src
-	url = https://github.com/konstantysz/desmume.git
+	url = https://github.com/TASEmulators/desmume.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "desmume_src"]
 	path = desmume_src
-	url = https://github.com/TASEmulators/desmume.git
+	url = https://github.com/SkyTemple/desmume.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "desmume_src"]
 	path = desmume_src
-	url = https://github.com/SkyTemple/desmume.git
+	url = https://github.com/konstantysz/desmume.git

--- a/desmume/emulator.py
+++ b/desmume/emulator.py
@@ -270,10 +270,10 @@ class DeSmuME_Backup:
         if not os.path.exists(file_path):
             raise FileNotFoundError(f"Backup file not found: {file_path}")
 
-        self.emu.lib.desmume_backup_import_raw.argtypes = [c_char_p, c_uint]
-        self.emu.lib.desmume_backup_import_raw.restype = c_int
+        self.emu.lib.desmume_backup_import_file.argtypes = [c_char_p, c_uint]
+        self.emu.lib.desmume_backup_import_file.restype = c_int
 
-        result = self.emu.lib.desmume_backup_import_raw(
+        result = self.emu.lib.desmume_backup_import_file(
             c_char_p(strbytes(file_path)),
             c_uint(force_size)
         )

--- a/desmume/emulator.py
+++ b/desmume/emulator.py
@@ -258,32 +258,9 @@ class DeSmuME_Backup:
     def __init__(self, emu: 'DeSmuME'):
         self.emu = emu
 
-    def import_file(self, file_path: str) -> bool:
+    def import_file(self, file_path: str, force_size: int = 0) -> bool:
         """
-        Import battery save file (.sav, .dsv, .duc, etc.)
-
-        Imports backup memory from a file. Supports multiple formats with automatic detection.
-        The emulator will automatically reset after successful import.
-
-        :param file_path: Path to backup save file
-        :return: True if import succeeded, False otherwise
-        :raise: FileNotFoundError if the file doesn't exist
-        """
-        if not os.path.exists(file_path):
-            raise FileNotFoundError(f"Backup file not found: {file_path}")
-
-        self.emu.lib.desmume_backup_import_file.argtypes = [c_char_p]
-        self.emu.lib.desmume_backup_import_file.restype = c_int
-
-        result = self.emu.lib.desmume_backup_import_file(c_char_p(strbytes(file_path)))
-        return bool(result)
-
-    def import_raw(self, file_path: str, force_size: int = 0) -> bool:
-        """
-        Import raw battery save with forced size.
-
-        Similar to import_file() but allows forcing a specific backup device size.
-        Useful when auto-detection fails.
+        Import raw battery save.
 
         :param file_path: Path to raw .sav file
         :param force_size: Size in bytes (0 = auto-detect)


### PR DESCRIPTION
## Summary
Adds Python bindings for battery save import/export to match the new DeSmuME interface API.

## Dependencies
⚠️ **Requires DeSmuME PR**: https://github.com/TASEmulators/desmume/pull/930]

This PR temporarily points the `desmume_src` submodule to my fork until the upstream PR is merged.

## Changes
- Added `DeSmuME_Backup` class with three methods:
  - `backup.import_file(path)` - auto-detects format (.sav, .dsv, .duc, .dss)
  - `backup.import_raw(path, size)` - manual size override
  - `backup.export_file(path)` - export to .dsv
- Added `backup` property to `DeSmuME` class
- Temporarly updated submodule to konstantysz/desmume fork

## Usage Example
```python
from desmume.emulator import DeSmuME

emu = DeSmuME()
emu.open('pokemon_black2.nds')

# Import battery save
if emu.backup.import_file('my_save.sav'):
    print("Save loaded!")
```

## Use Case
I'm building a Pokemon shiny hunting tool that needs to load battery saves programmatically across multiple emulator instances. Currently there's no way to do this without manual GUI interaction.

## Testing
Functional testing pending - will compile custom libdesmume.dll and test with Pokemon ROMs once DeSmuME PR is reviewed.
Once the upstream DeSmuME PR merges, I'll update the submodule to point back to SkyTemple/desmume.

---