### PR TITLE
Fix GitHub Actions CI builds

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -92,7 +92,7 @@ jobs:
           CIBW_SKIP: "*musllinux*"
           CIBW_BEFORE_ALL_LINUX: "{package}/build-manylinux.sh"
           CIBW_BEFORE_BUILD_WINDOWS: "rm -rf desmume_src/desmume/src/frontend/interface/windows/__bins"
-          CIBW_ENVIRONMENT_LINUX: 'CXXFLAGS="-DFORCE_AVX512_0=1 -D_POSIX_C_SOURCE=200809L" CFLAGS="-D_POSIX_C_SOURCE=200809L"'
+          CIBW_ENVIRONMENT_LINUX: 'CXXFLAGS="-DFORCE_AVX512_0=1 -D_GNU_SOURCE" CFLAGS="-D_GNU_SOURCE"'
           CIBW_ENVIRONMENT_WINDOWS: "${{ env.CIBW_ENVIRONMENT_WINDOWS }}"
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
           CIBW_MANYLINUX_PYPY_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -26,9 +26,9 @@ jobs:
             arch: x86_64
           - os: macos-14
             arch: arm64
-          - os: windows-2019
+          - os: windows-2022
             arch: x86
-          - os: windows-2019
+          - os: windows-2022
             arch: AMD64
     steps:
       - name: Checkout
@@ -118,7 +118,7 @@ jobs:
           name: wheels-sdist
           path: dist/*.tar.gz
   build_mingw:
-    runs-on: windows-2019
+    runs-on: windows-2022
     name: Msys Wheel
     strategy:
       fail-fast: false

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -139,7 +139,6 @@ jobs:
             mingw-w64-${{ matrix.arch }}-curl
             mingw-w64-${{ matrix.arch }}-python
             mingw-w64-${{ matrix.arch }}-python-pip
-            mingw-w64-${{ matrix.arch }}-python-pillow
             mingw-w64-${{ matrix.arch }}-openssl
             mingw-w64-${{ matrix.arch }}-toolchain
       - name: Checkout

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -92,7 +92,7 @@ jobs:
           CIBW_SKIP: "*musllinux*"
           CIBW_BEFORE_ALL_LINUX: "{package}/build-manylinux.sh"
           CIBW_BEFORE_BUILD_WINDOWS: "rm -rf desmume_src/desmume/src/frontend/interface/windows/__bins"
-          CIBW_ENVIRONMENT_LINUX: 'CXXFLAGS="-DFORCE_AVX512_0=1 -D_POSIX_C_SOURCE=199309L" CFLAGS="-D_POSIX_C_SOURCE=199309L"'
+          CIBW_ENVIRONMENT_LINUX: 'CXXFLAGS="-DFORCE_AVX512_0=1 -D_POSIX_C_SOURCE=200809L" CFLAGS="-D_POSIX_C_SOURCE=200809L"'
           CIBW_ENVIRONMENT_WINDOWS: "${{ env.CIBW_ENVIRONMENT_WINDOWS }}"
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
           CIBW_MANYLINUX_PYPY_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -22,7 +22,7 @@ jobs:
             arch: x86_64
           - os: ubuntu-latest
             arch: aarch64
-          - os: macos-12
+          - os: macos-13
             arch: x86_64
           - os: macos-14
             arch: arm64
@@ -69,10 +69,10 @@ jobs:
         shell: bash
         run: |
           echo CIBW_ENVIRONMENT_WINDOWS="FASTBUILD=1 BUILD_32=1" >> $GITHUB_ENV
-      - name: "MacOS 12: Set deployment target"
-        if: matrix.os == 'macos-12'
+      - name: "MacOS 13: Set deployment target"
+        if: matrix.os == 'macos-13'
         run: |
-          echo "MACOSX_DEPLOYMENT_TARGET=12.0" >> $GITHUB_ENV
+          echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> $GITHUB_ENV
       - name: "MacOS 14: Set deployment target & fix arch flags"
         if: matrix.os == 'macos-14'
         run: |

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Build Python wheels  # microsoft/setup-msbuild@v1.3.1 doesn't work here
         shell: msys2 {0}
         run: |
-          PATH="$PATH:/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin" python setup.py bdist_wheel
+          PATH="$PATH:/c/Program Files/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin" python setup.py bdist_wheel
         env:
           BUILD_32: "${{ matrix.arch == 'x86' && '1' || '' }}"
           FASTBUILD: "1"

--- a/README.rst
+++ b/README.rst
@@ -35,3 +35,26 @@ for Linux, Windows and MacOS.
 
 Documentation can be found in the ``docs`` directory and at
 https://py-desmume.readthedocs.org.
+
+Build Requirements
+------------------
+
+**For using pre-built wheels (recommended):**
+
+Simply install via pip - all dependencies are included.
+
+**For building from source:**
+
+Linux:
+
+- SDL2 >= 2.0.14 (for full game controller support including touchpad features)
+- Other dependencies: zlib, libpcap, soundtouch, openal-soft, glib2, meson
+
+macOS:
+
+- Install via Homebrew: ``brew install sdl2 meson glib gcc``
+
+Windows:
+
+- Visual Studio 2019 or later
+- SDL2 is included in the repository

--- a/build-manylinux.sh
+++ b/build-manylinux.sh
@@ -5,4 +5,22 @@ set -e
 rm __build_desmume -rf || true
 rm build -rf || true
 
-yum install zlib-devel libpcap-devel SDL2-devel soundtouch-devel openal-soft-devel glib2-devel libtool autoconf automake meson -y
+# Install base dependencies (except SDL2, which we'll build from source)
+yum install zlib-devel libpcap-devel soundtouch-devel openal-soft-devel glib2-devel libtool autoconf automake meson wget -y
+
+# Build SDL2 2.0.22 from source (requires SDL >= 2.0.14 for touchpad APIs)
+# See: https://github.com/TASEmulators/desmume/issues/935
+SDL2_VERSION="2.0.22"
+cd /tmp
+wget https://www.libsdl.org/release/SDL2-${SDL2_VERSION}.tar.gz
+tar -xzf SDL2-${SDL2_VERSION}.tar.gz
+cd SDL2-${SDL2_VERSION}
+./configure --prefix=/usr/local
+make -j$(nproc)
+make install
+cd /
+rm -rf /tmp/SDL2-${SDL2_VERSION}*
+
+# Ensure pkg-config can find SDL2
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
## Summary

- Fix SDL2 compatibility by building from source for Linux wheels
- Update deprecated Windows runners to windows-2022
- Fix POSIX/GNU source compatibility for strdup/realpath
- Remove non-existent pillow dependency from MSYS2 build
- Update MSBuild path for Visual Studio 2022

## Changes

### SDL2 Compatibility ([#935](https://github.com/TASEmulators/desmume/issues/935))
- Build SDL2 2.0.22 from source in manylinux environment
- Required for touchpad API support (SDL >= 2.0.14)
- Adds ~5-10 min to Linux wheel build time

### Windows Runner Updates
- Replace deprecated windows-2019 with windows-2022 (3 occurrences)
- Update MSBuild path from VS 2019 to VS 2022 for MSYS builds

### Linux Build Compatibility
- Use `_GNU_SOURCE` instead of `_POSIX_C_SOURCE` for broader compatibility
- Fixes implicit declaration errors for strdup/realpath functions

### MSYS2 Dependencies
- Remove non-existent `mingw-w64-${{matrix.arch}}-python-pillow` package

### Documentation
- Add build requirements section to README.rst
- Document SDL2 version requirements for source builds