### PR TITLE
Fix mac build

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -22,7 +22,7 @@ jobs:
             arch: x86_64
           - os: ubuntu-latest
             arch: aarch64
-          - os: macos-14
+          - os: macos-15-intel
             arch: x86_64
           - os: macos-14
             arch: arm64
@@ -69,15 +69,15 @@ jobs:
         shell: bash
         run: |
           echo CIBW_ENVIRONMENT_WINDOWS="FASTBUILD=1 BUILD_32=1" >> $GITHUB_ENV
-      - name: "MacOS 14 x64: Set deployment target & fix arch flags"
-        if: matrix.os == 'macos-14' && matrix.arch == 'x86_64'
+      - name: "MacOS 15 x64: Set deployment target"
+        if: matrix.os == 'macos-15-intel' && matrix.arch == 'x86_64'
         run: |
-          echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
-          echo "CPPFLAGS=-arch x86_64" >> $GITHUB_ENV
+          echo "MACOSX_DEPLOYMENT_TARGET=15.0" >> $GITHUB_ENV
       - name: "MacOS 14 arm: Set deployment target & fix arch flags"
         if: matrix.os == 'macos-14' && matrix.arch == 'arm64'
         run: |
           echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
+          # This really shouldn't be needed though??
           echo "CPPFLAGS=-arch arm64" >> $GITHUB_ENV
       - name: Add msbuild to PATH
         if: runner.os == 'Windows'

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -22,7 +22,7 @@ jobs:
             arch: x86_64
           - os: ubuntu-latest
             arch: aarch64
-          - os: macos-13
+          - os: macos-14
             arch: x86_64
           - os: macos-14
             arch: arm64
@@ -69,12 +69,12 @@ jobs:
         shell: bash
         run: |
           echo CIBW_ENVIRONMENT_WINDOWS="FASTBUILD=1 BUILD_32=1" >> $GITHUB_ENV
-      - name: "MacOS 13: Set deployment target"
-        if: matrix.os == 'macos-13'
+      - name: "MacOS 14 x64: Set deployment target"
+        if: matrix.os == 'macos-14' && matrix.arch == 'x86_64'
         run: |
-          echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> $GITHUB_ENV
-      - name: "MacOS 14: Set deployment target & fix arch flags"
-        if: matrix.os == 'macos-14'
+          echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
+      - name: "MacOS 14 arm: Set deployment target & fix arch flags"
+        if: matrix.os == 'macos-14' && matrix.arch == 'arm64'
         run: |
           echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
           # This really shouldn't be needed though??

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -69,15 +69,15 @@ jobs:
         shell: bash
         run: |
           echo CIBW_ENVIRONMENT_WINDOWS="FASTBUILD=1 BUILD_32=1" >> $GITHUB_ENV
-      - name: "MacOS 14 x64: Set deployment target"
+      - name: "MacOS 14 x64: Set deployment target & fix arch flags"
         if: matrix.os == 'macos-14' && matrix.arch == 'x86_64'
         run: |
           echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
+          echo "CPPFLAGS=-arch x86_64" >> $GITHUB_ENV
       - name: "MacOS 14 arm: Set deployment target & fix arch flags"
         if: matrix.os == 'macos-14' && matrix.arch == 'arm64'
         run: |
           echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
-          # This really shouldn't be needed though??
           echo "CPPFLAGS=-arch arm64" >> $GITHUB_ENV
       - name: Add msbuild to PATH
         if: runner.os == 'Windows'


### PR DESCRIPTION
The Mac 13 runner reached EOL recently and no longer works, so releases don't work either. This PR bumps the Mac version to 14 to fix the build.